### PR TITLE
Fix bug in Share.php

### DIFF
--- a/src/Thujohn/Share/Share.php
+++ b/src/Thujohn/Share/Share.php
@@ -8,7 +8,7 @@ class Share {
 	public function load($link, $text = '', $media = ''){
 		$this->link = urlencode($link);
 		$this->text = urlencode($text);
-		$this->text = urlencode($media);
+		$this->media = urlencode($media);
 
 		return $this;
 	}


### PR DESCRIPTION
Line no. 11. Erroneous code:

$this->text= urlencode($media);

Change to:

$this->media = urlencode($media);

Problem: The bug overwrites the assignment done in the line above it.

How to replicate: Share on any network, and you can't see the title of the shared page correctly.
