### PR TITLE
Add vk.com

### DIFF
--- a/src/Thujohn/Share/Share.php
+++ b/src/Thujohn/Share/Share.php
@@ -84,4 +84,8 @@ class Share {
 	public function viadeo(){
 		return 'http://www.viadeo.com/?url='.$this->link.(($this->text) ? '&title='.$this->text : '');
 	}
+	
+	public function vk(){
+		return 'http://vk.com/share.php?url='.$this->link.(($this->media) ? '&image='.$this->media : '').(($this->text) ? '&title='.$this->text : '').'&noparse=false';
+	}
 }


### PR DESCRIPTION
Add share url of the largest social network website in Russia and NIS countries [vk.com](http://vk.com)
- setting `noparse` to `false` allows automatical retrieving missing description, title or media.

Visit http://vk.com/dev/share_details for more info.

_NIS stands for_ **Newly Independent States** _or_ **Post-Soviet states**
